### PR TITLE
module.info: name the module itself via Module:

### DIFF
--- a/module.info
+++ b/module.info
@@ -1,0 +1,1 @@
+Module: doc


### PR DESCRIPTION
[You clearly told me](https://community.icinga.com/t/new-icinga-web-module-repo-naming-scheme/3775/2?u=al2klimov) that my current auto-discovery's base won't survive. But the only other option is broken – here's the fix.